### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,103 @@
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+    - env: CABALVER=1.16 GHCVER=7.6.3
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.1
+      compiler: ": #GHC 7.8.1"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.1], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.2
+      compiler: ": #GHC 7.8.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.3
+      compiler: ": #GHC 7.8.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.1
+      compiler: ": #GHC 7.10.1"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.2
+      compiler: ": #GHC 7.10.2"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=head
+      compiler: ": #GHC head"
+      addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+
+  allow_failures:
+    - env: CABALVER=head GHCVER=head
+
+before_install:
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+
+# EOF

--- a/gen-travis-yml.hs
+++ b/gen-travis-yml.hs
@@ -1,0 +1,203 @@
+#!/usr/bin/env runghc
+
+-- NB: This code deliberately avoids relying on non-standard packages
+
+import Control.Monad
+import Data.List
+import System.Environment
+import System.Exit
+import System.IO
+
+import Distribution.PackageDescription.Parse (readPackageDescription)
+import Distribution.PackageDescription (packageDescription, testedWith)
+import Distribution.Compiler (CompilerFlavor(..))
+import Distribution.Version
+import Distribution.Text
+
+putStrLnErr :: String -> IO ()
+putStrLnErr m = hPutStrLn stderr ("*ERROR* " ++ m) >> exitFailure
+
+putStrLnWarn :: String -> IO ()
+putStrLnWarn m = hPutStrLn stderr ("*WARNING* " ++ m)
+
+putStrLnInfo :: String -> IO ()
+putStrLnInfo m = hPutStrLn stderr ("*INFO* " ++ m)
+
+main :: IO ()
+main = do
+    args <- getArgs
+    case args of
+        (cabfn:xpkgs) -> do genTravisFromCabalFile cabfn xpkgs
+        _ -> putStrLnErr (unlines $ [ "expected .cabal file as command-line argument"
+                                    , "Usage: make_travis_yml.hs <cabal-file> <extra-apt-packages...>"
+                                    , ""
+                                    , "Example: make_travis_yml.hs someProject.cabal alex-3.1.4 liblzma-dev > .travis.yml"
+                                    ])
+
+genTravisFromCabalFile :: FilePath -> [String] -> IO ()
+genTravisFromCabalFile fn xpkgs = do
+    gpd <- readPackageDescription maxBound fn
+
+    let compilers = testedWith $ packageDescription $ gpd
+
+    let unknownComps = nub [ c | (c,_) <- compilers, c /= GHC ]
+        ghcVerConstrs = [ vc | (GHC,vc) <- compilers ]
+        ghcVerConstrs' = simplifyVersionRange $ foldr unionVersionRanges noVersion ghcVerConstrs
+
+    when (null compilers) $ do
+        putStrLnErr "empty or missing 'tested-with:' definition in .cabal file"
+
+    unless (null unknownComps) $ do
+        putStrLnWarn $ "ignoring unsupported compilers mentioned in tested-with: " ++ show unknownComps
+
+    when (null ghcVerConstrs) $ do
+        putStrLnErr "'tested-with:' doesn't mention any 'GHC' version"
+
+    when (isNoVersion ghcVerConstrs') $ do
+        putStrLnErr "'tested-with:' describes an empty version range for 'GHC'"
+
+    when (isAnyVersion ghcVerConstrs') $ do
+        putStrLnErr "'tested-with:' allows /any/ 'GHC' version"
+
+    let testedGhcVersions = filter (`withinRange` ghcVerConstrs') knownGhcVersions
+
+    when (null testedGhcVersions) $ do
+        putStrLnErr "no known GHC version is allowed by the 'tested-with' specification"
+
+    putStrLnInfo $ "Generating Travis-CI config for testing for GHC versions: " ++ (unwords $ map disp' $ testedGhcVersions)
+
+    ----------------------------------------------------------------------------
+    -- travis.yml generation starts here
+
+    putStrLn "# This file has been generated -- see https://github.com/hvr/multi-ghc-travis"
+    putStrLn "language: c"
+    putStrLn "sudo: false"
+    putStrLn ""
+    putStrLn "cache:"
+    putStrLn "  directories:"
+    putStrLn "    - $HOME/.cabsnap"
+    putStrLn "    - $HOME/.cabal/packages"
+    putStrLn ""
+    putStrLn "before_cache:"
+    putStrLn "  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log"
+    putStrLn "  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar"
+    putStrLn ""
+    putStrLn "matrix:"
+    putStrLn "  include:"
+
+    forM_ testedGhcVersions $ \gv -> do
+        let cvs = disp' (lookupCabVer gv)
+            gvs = disp' gv
+
+            xpkgs' = concatMap (',':) xpkgs
+
+        putStrLn $ concat [ "    - env: CABALVER=", cvs, " GHCVER=", gvs ]
+        putStrLn $ concat [ "      compiler: \": #GHC ", gvs, "\"" ]
+        putStrLn $ concat [ "      addons: {apt: {packages: [cabal-install-", cvs, ",ghc-", gvs, xpkgs'
+                          , "], sources: [hvr-ghc]}}" ]
+        return ()
+
+    let headGhcVers = filter isHead testedGhcVersions
+
+    unless (null headGhcVers) $ do
+        putStrLn ""
+        putStrLn "  allow_failures:"
+
+    forM_ headGhcVers $ \gv -> do
+        let cvs = disp' (lookupCabVer gv)
+            gvs = disp' gv
+        putStrLn $ concat [ "    - env: CABALVER=", cvs, " GHCVER=", gvs ]
+
+    putStrLn ""
+    putStrLn "before_install:"
+    putStrLn " - unset CC"
+    putStrLn " - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH"
+
+    putStrLn ""
+
+    putStr $ unlines
+        [ "install:"
+        , " - cabal --version"
+        , " - echo \"$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]\""
+        , " - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];"
+        , "   then"
+        , "     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >"
+        , "          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;"
+        , "   fi"
+        , " - travis_retry cabal update -v"
+        , " - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config"
+        , " - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt"
+        , " - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt"
+        , ""
+        , "# check whether current requested install-plan matches cached package-db snapshot"
+        , " - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;"
+        , "   then"
+        , "     echo \"cabal build-cache HIT\";"
+        , "     rm -rfv .ghc;"
+        , "     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;"
+        , "     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;"
+        , "   else"
+        , "     echo \"cabal build-cache MISS\";"
+        , "     rm -rf $HOME/.cabsnap;"
+        , "     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;"
+        , "     cabal install --only-dependencies --enable-tests --enable-benchmarks;"
+        , "   fi"
+        , ""
+        , "# snapshot package-db on cache miss"
+        , " - if [ ! -d $HOME/.cabsnap ];"
+        , "   then"
+        , "      echo \"snapshotting package-db to build-cache\";"
+        , "      mkdir $HOME/.cabsnap;"
+        , "      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;"
+        , "      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;"
+        , "   fi"
+        , ""
+        , "# Here starts the actual work to be performed for the package under test;"
+        , "# any command which exits with a non-zero exit code causes the build to fail."
+        , "script:"
+        , " - if [ -f configure.ac ]; then autoreconf -i; fi"
+        , " - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging"
+        , " - cabal build   # this builds all libraries and executables (including tests/benchmarks)"
+        , " - cabal test"
+        , " - cabal check"
+        , " - cabal sdist   # tests that a source-distribution can be generated"
+        , ""
+        , "# Check that the resulting source distribution can be built & installed."
+        , "# If there are no other `.tar.gz` files in `dist`, this can be even simpler:"
+        , "# `cabal install --force-reinstalls dist/*-*.tar.gz`"
+        , " - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&"
+        , "   (cd dist && cabal install --force-reinstalls \"$SRC_TGZ\")"
+        , ""
+        , "# EOF"
+        ]
+
+    return ()
+  where
+    knownGhcVersions :: [Version]
+    knownGhcVersions = fmap (`Version` [])
+                       [ [7,0,1],  [7,0,2], [7,0,3], [7,0,4]
+                       , [7,2,1],  [7,2,2]
+                       , [7,4,1],  [7,4,2]
+                       , [7,6,1],  [7,6,2], [7,6,3]
+                       , [7,8,1],  [7,8,2], [7,8,3], [7,8,4]
+                       , [7,10,1], [7,10,2], [7,10,3]
+                       , [7,11] -- HEAD
+                       ]
+
+    lookupCabVer :: Version -> Version
+    lookupCabVer (Version (x:y:_) _) = maybe (error "internal error") id $ lookup (x,y) cabalVerMap
+      where
+        cabalVerMap = fmap (fmap (`Version` []))
+                      [ ((7, 0),  [1,16])
+                      , ((7, 2),  [1,16])
+                      , ((7, 4),  [1,16])
+                      , ((7, 6),  [1,16])
+                      , ((7, 8),  [1,18])
+                      , ((7,10), [1,22])
+                      , ((7,11), [1,23]) -- HEAD
+                      ]
+
+    isHead (Version (_:y:_) _) = odd (y :: Int)
+
+    disp' v | isHead v = "head"
+            | otherwise = display v

--- a/hpygments.cabal
+++ b/hpygments.cabal
@@ -13,6 +13,8 @@ Category:           Text
 Build-type:         Simple
 Cabal-version:      >=1.6
 
+tested-with: GHC >= 7.6.3
+
 Extra-source-files:
     README.md
 

--- a/hpygments.cabal
+++ b/hpygments.cabal
@@ -40,6 +40,6 @@ Library
   Build-depends:
     base >= 4 && < 5,
     bytestring,
-    process,
-    process-extras == 0.2.*,
-    aeson == 0.6.1.*
+    process >=1.2 && <1.3,
+    process-extras >=0.3 && <0.4,
+    aeson >=0.8 && <0.9

--- a/hpygments.cabal
+++ b/hpygments.cabal
@@ -1,47 +1,40 @@
-Name:               hpygments
-Version:            0.1.3
-Synopsis:           Highlight source code using Pygments
-Description:
+name: hpygments
+version: 0.1.3
+cabal-version: >=1.6
+build-type: Simple
+license: MIT
+license-file: LICENSE
+maintainer: David Lazar <lazar6@illinois.edu>
+homepage: https://github.com/davidlazar/hpygments
+synopsis: Highlight source code using Pygments
+description:
     Highlight source code using Pygments <http://pygments.org>. This package
     depends on Pygments and its accompanying @pygmentize@ script.
-Homepage:           https://github.com/davidlazar/hpygments
-License:            MIT
-License-file:       LICENSE
-Author:             David Lazar
-Maintainer:         David Lazar <lazar6@illinois.edu>
-Category:           Text
-Build-type:         Simple
-Cabal-version:      >=1.6
-
-tested-with: GHC >= 7.6.3
-
-Extra-source-files:
+category: Text
+author: David Lazar
+tested-with: GHC >=7.6.3
+data-files:
+    pygments_dump_json.py
+extra-source-files:
     README.md
 
-Data-files:
-    pygments_dump_json.py
-
 source-repository head
-  Type:             git
-  Location:         https://github.com/davidlazar/hpygments
+    type: git
+    location: https://github.com/davidlazar/hpygments
 
-Library
-  ghc-options:      -Wall
-
-  Hs-source-dirs:   src
-
-  Exposed-modules:
-    Text.Highlighting.Pygments
-    Text.Highlighting.Pygments.Lexers
-    Text.Highlighting.Pygments.Formatters
-
-  Other-modules:
-    Text.Highlighting.Pygments.JSON
-    Paths_hpygments
-
-  Build-depends:
-    base >= 4 && < 5,
-    bytestring,
-    process >=1.2 && <1.3,
-    process-extras >=0.3 && <0.4,
-    aeson >=0.8 && <0.9
+library
+    exposed-modules:
+        Text.Highlighting.Pygments
+        Text.Highlighting.Pygments.Lexers
+        Text.Highlighting.Pygments.Formatters
+    build-depends:
+        base >=4 && <5,
+        bytestring -any,
+        process >=1.2 && <1.3,
+        process-extras >=0.3 && <0.4,
+        aeson >=0.8 && <0.9
+    hs-source-dirs: src
+    other-modules:
+        Text.Highlighting.Pygments.JSON
+        Paths_hpygments
+    ghc-options: -Wall

--- a/src/Text/Highlighting/Pygments/Formatters.hs
+++ b/src/Text/Highlighting/Pygments/Formatters.hs
@@ -15,10 +15,9 @@ module Text.Highlighting.Pygments.Formatters
     , terminalFormatter
     ) where
 
-import Data.Aeson.TH (deriveJSON)
-import Data.Maybe (listToMaybe)
-
-import Text.Highlighting.Pygments.JSON
+import           Data.Aeson.TH                   (defaultOptions, deriveJSON)
+import           Data.Maybe                      (listToMaybe)
+import           Text.Highlighting.Pygments.JSON
 
 type FormatterAlias = String
 
@@ -27,7 +26,7 @@ data Formatter = Formatter
     , _formatterAliases :: [FormatterAlias]
     } deriving (Eq, Ord, Show)
 
-$(deriveJSON id ''Formatter)
+$(deriveJSON defaultOptions ''Formatter)
 
 getAllFormatters :: IO [Formatter]
 getAllFormatters = getPygmentsJSON "formatters"

--- a/src/Text/Highlighting/Pygments/Lexers.hs
+++ b/src/Text/Highlighting/Pygments/Lexers.hs
@@ -18,10 +18,10 @@ module Text.Highlighting.Pygments.Lexers
     , textLexer
     ) where
 
-import Data.Aeson.TH (deriveJSON)
-import Data.Maybe (listToMaybe)
+import           Data.Aeson.TH                   (defaultOptions, deriveJSON)
+import           Data.Maybe                      (listToMaybe)
 
-import Text.Highlighting.Pygments.JSON
+import           Text.Highlighting.Pygments.JSON
 
 type LexerAlias = String
 
@@ -32,7 +32,7 @@ data Lexer = Lexer
     , _lexerMimeTypes :: [String]
     } deriving (Eq, Ord, Show)
 
-$(deriveJSON id ''Lexer)
+$(deriveJSON defaultOptions ''Lexer)
 
 getAllLexers :: IO [Lexer]
 getAllLexers = getPygmentsJSON "lexers"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,32 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.17
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.10.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
Fixes build on the latest LTS Haskell. Also adds a `.travis.yml` and `cabal format`s the `.cabal` file.

See the build here: https://travis-ci.org/yamadapc/hpygments/builds

We can also let the boundaries loose and see what happens; but working on LTS is good enough for my use.
